### PR TITLE
Fix type typo in models/user.py

### DIFF
--- a/twitch/helix/models/user.py
+++ b/twitch/helix/models/user.py
@@ -50,7 +50,7 @@ class User(Model):
 
     def following(self, **kwargs) -> 'helix.Follows':
         kwargs['from_id'] = self.id
-        return helix.Follows(api=self._api, follow_type='following', **kwargs)
+        return helix.Follows(api=self._api, follow_type='followings', **kwargs)
 
     def followers(self, **kwargs) -> 'helix.Follows':
         kwargs['to_id'] = self.id


### PR DESCRIPTION
There was a mismatch in the follow_type value between models/user.py and resources/follows.py