### PR TITLE
Added ability to define a socket timeout and subscribable callback for when irc thread closes

### DIFF
--- a/twitch/chat/chat.py
+++ b/twitch/chat/chat.py
@@ -9,7 +9,7 @@ import twitch.chat as chat
 
 class Chat(Subject):
 
-    def __init__(self, channel: str, nickname: str, oauth: str, helix: Optional['twitch.Helix'] = None):
+    def __init__(self, channel: str, nickname: str, oauth: str, helix: Optional['twitch.Helix'] = None, timeout = 0):
         """
         :param channel: Channel name
         :param nickname: User nickname
@@ -19,7 +19,7 @@ class Chat(Subject):
         super().__init__()
         self.helix: Optional['twitch.Helix'] = helix
 
-        self.irc = chat.IRC(nickname, password=oauth)
+        self.irc = chat.IRC(nickname, password=oauth, timeout=timeout)
         self.irc.incoming.subscribe(self._message_handler)
         self.irc.start()
 

--- a/twitch/chat/irc.py
+++ b/twitch/chat/irc.py
@@ -12,8 +12,8 @@ class IRC(threading.Thread):
         super().__init__()
 
         self.timeout = timeout
-        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)    
-        self.reset_timeout()   
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.reset_timeout()
         self.address: str = address
         self.port: int = port
         self.channels: List[str] = []
@@ -21,7 +21,7 @@ class IRC(threading.Thread):
         self.password: str = 'oauth:' + password.lstrip('oauth:')
         self.active: bool = True
         self.incoming: Subject = Subject()
-        self.thread_close: Subject = Subject()        
+        self.thread_close: Subject = Subject()
 
     def run(self):
         self.connect()
@@ -41,7 +41,7 @@ class IRC(threading.Thread):
                     return
 
                 # Publish data to subscribers
-                self.incoming.on_next(data)  
+                self.incoming.on_next(data)
 
             except IOError:
                 break
@@ -50,7 +50,7 @@ class IRC(threading.Thread):
 
     def reset_timeout(self):
         if(self.timeout != 0):
-            self.socket.settimeout(self.timeout) 
+            self.socket.settimeout(self.timeout)
 
     def send_raw(self, message: str) -> None:
         data = (message.lstrip('\n') + '\n').encode('utf-8')


### PR DESCRIPTION
I added this as a result of unreliable thread disposal via existing methods.
Occasionally the irc socket will simply stop receiving from Twitch and become stuck in the socket.recv method (irc.py line 88). This is resolved by setting a reasonable socket timeout closing stuck threads.
The 'thread_close' callback was also added to allow for recovery of chat functionality by the host application, subscribers have an accurate way of knowing when the previous connection has fully closed and creating a new one if desired.