### PR TITLE
Correctly strip "bearer" from bearer tokens.

### DIFF
--- a/twitch/helix/helix.py
+++ b/twitch/helix/helix.py
@@ -38,13 +38,16 @@ class Helix:
                                          f"&client_secret={client_secret}"
                                          "&grant_type=client_credentials").json()['access_token']
 
+        if bearer_token.lower().starts_with('bearer'):
+            bearer_token = bearer_token[6:0]
+        
         self.api = API(Helix.BASE_URL,
                        client_id=client_id,
                        client_secret=client_secret,
                        use_cache=use_cache,
                        cache_duration=cache_duration,
                        handle_rate_limit=handle_rate_limit,
-                       bearer_token='Bearer ' + bearer_token.lower().lstrip('bearer').strip())
+                       bearer_token='Bearer ' + bearer_token.lower().strip())
 
     def users(self, *args) -> 'helix.Users':
         return helix.Users(self.api, *args)

--- a/twitch/helix/helix.py
+++ b/twitch/helix/helix.py
@@ -38,15 +38,9 @@ class Helix:
                                          f"&client_secret={client_secret}"
                                          "&grant_type=client_credentials").json()['access_token']
 
-<<<<<<< HEAD
         if bearer_token.lower().startswith('bearer'):
             bearer_token = bearer_token[6:0]
 
-=======
-        if bearer_token.lower().starts_with('bearer'):
-            bearer_token = bearer_token[6:0]
-        
->>>>>>> 4f0d3bd452d91d6c88b39cb1520566b0e0503344
         self.api = API(Helix.BASE_URL,
                        client_id=client_id,
                        client_secret=client_secret,

--- a/twitch/helix/helix.py
+++ b/twitch/helix/helix.py
@@ -38,13 +38,16 @@ class Helix:
                                          f"&client_secret={client_secret}"
                                          "&grant_type=client_credentials").json()['access_token']
 
+        if bearer_token.lower().startswith('bearer'):
+            bearer_token = bearer_token[6:0]
+
         self.api = API(Helix.BASE_URL,
                        client_id=client_id,
                        client_secret=client_secret,
                        use_cache=use_cache,
                        cache_duration=cache_duration,
                        handle_rate_limit=handle_rate_limit,
-                       bearer_token='Bearer ' + bearer_token.lower().lstrip('bearer').strip())
+                       bearer_token='Bearer ' + bearer_token.lower().strip())
 
     def users(self, *args) -> 'helix.Users':
         return helix.Users(self.api, *args)


### PR DESCRIPTION
`string.lstrip(str)` strips from the start of `string` any number of characters which match the characters in `str`. It does _not_ strip from the start of `string` the string `str`. The result of the current code is that if the Twitch API returns the bearer token _without_ the word `Bearer` at the start (which in my experience is, in fact, the case) then any characters in the word 'Bearer' will be stripped from the start of the **actual bearer token**.

Given this is not the intended behaviour, this pull request proposes to instead check if the API has returned a string starting with `Bearer`, and if it has, to remove the first six characters from that string. This does, however, leave open a 1 in 2,176,782,336 chance that the actual bearer token starts with the characters `bearer` in that order, assuming this edge case isn't already filtered out by the Twitch API. Further work may be required.