### PR TITLE
Request tags for IRC messages

### DIFF
--- a/twitch/chat/irc.py
+++ b/twitch/chat/irc.py
@@ -57,6 +57,9 @@ class IRC(threading.Thread):
         self.send_raw(f'PASS {self.password}')
         self.send_raw(f'NICK {self.nickname}')
 
+    def activate_tags(self) -> None:
+        self.send_raw(f'CAP REQ :twitch.tv/tags')
+
     def join_channel(self, channel: str) -> None:
         channel = channel.lstrip('#')
         self.channels.append(channel)

--- a/twitch/chat/message.py
+++ b/twitch/chat/message.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 
 from twitch.helix import User, Helix
 from .chat import Chat
@@ -11,12 +11,14 @@ class Message:
                  sender: str,
                  text: str,
                  helix_api: Optional[Helix] = None,
-                 chat: Optional[Chat] = None):
+                 chat: Optional[Chat] = None,
+                 tags: Optional[Dict] = None):
         self.channel: str = channel
         self.sender: str = sender
         self.text: str = text
         self.helix: Optional[Helix] = helix_api
         self.chat: Optional[Chat] = chat
+        self.tags: Optional[Dict] = tags
 
     @property
     def user(self) -> Optional[User]:


### PR DESCRIPTION
Twitch offers additional information on chat messages if the client requests them. This information includes User color, subscription state and many more. See https://dev.twitch.tv/docs/irc/tags

After authentication we send a request to enable tags for incoming messages.
Message parsing is updated to deal with tagged and untagged messages.