### PR TITLE
Add IRC attribute to help error handling

### DIFF
--- a/twitch/chat/irc.py
+++ b/twitch/chat/irc.py
@@ -5,6 +5,7 @@ from typing import List
 
 from rx.subject import Subject
 
+from utils import TwitchChatError
 
 class IRC(threading.Thread):
 
@@ -34,7 +35,7 @@ class IRC(threading.Thread):
 
                 if text.find('Login authentication failed') > 0:
                     logging.fatal('IRC authentication error: ' + text or '')
-                    return
+                    raise TwitchChatError(text or 'IRC authentication error')
 
                 # Publish data to subscribers
                 self.incoming.on_next(data)

--- a/twitch/chat/irc.py
+++ b/twitch/chat/irc.py
@@ -5,7 +5,9 @@ from typing import List
 
 from rx.subject import Subject
 
-from utils import TwitchChatError
+class TwitchChatError(Exception):
+    pass
+
 
 class IRC(threading.Thread):
 
@@ -20,6 +22,7 @@ class IRC(threading.Thread):
         self.password: str = 'oauth:' + password.lstrip('oauth:')
         self.active: bool = True
         self.incoming: Subject = Subject()
+        self.exception = None
 
     def run(self):
         self.connect()
@@ -34,8 +37,9 @@ class IRC(threading.Thread):
                     self.send_raw('PONG ' + text.split()[1])
 
                 if text.find('Login authentication failed') > 0:
+                    # raise Exception(text or 'IRC authentication error')
                     logging.fatal('IRC authentication error: ' + text or '')
-                    raise TwitchChatError(text or 'IRC authentication error')
+                    self.exception = TwitchChatError(text)
 
                 # Publish data to subscribers
                 self.incoming.on_next(data)

--- a/twitch/chat/utils.py
+++ b/twitch/chat/utils.py
@@ -1,0 +1,7 @@
+
+
+class TwitchChatError(Exception):
+	
+	def __init__(self,message):
+		self.message = message
+		super().__init__(message)

--- a/twitch/chat/utils.py
+++ b/twitch/chat/utils.py
@@ -1,7 +1,0 @@
-
-
-class TwitchChatError(Exception):
-	
-	def __init__(self,message):
-		self.message = message
-		super().__init__(message)

--- a/twitch/utils.py
+++ b/twitch/utils.py
@@ -1,0 +1,12 @@
+
+
+class TwitchChatError(Exception):
+	
+	def __init__(self,message):
+		super().__init__(message)
+
+print('test')
+
+
+def print_test():
+	print('import test')


### PR DESCRIPTION
As mentioned in several issues, it would be nice to have a way to listen for the login failure.
In this PR I propose a very simple way to handle this : by adding an `exception` attribute to a `chat.irc` object, all users of the lib can listen for this attribute to be set with a TwitchChatError and raise this error.

This code does not conflict with the current state of the lib since *it does not raise the Exception itself*, but rather let the developpers listen for the event and raise or handle this themselves, therefore no compatibility issues.

This is follwowing the issue https://github.com/PetterKraabol/Twitch-Python/issues/32#issue-812267731